### PR TITLE
Feature/show all categories

### DIFF
--- a/debt/views.py
+++ b/debt/views.py
@@ -170,7 +170,7 @@ class CreditLineBulkUpdate(LoginRequiredMixin, generic.FormView):
                 path,
                 usecols=self.cols,
                 infer_datetime_format=True,
-                parse_dates=["statement_date"],
+                parse_dates=["date_opened"],
             )
         except ValueError as e:
             messages.error(self.request, f"Restore failed: {e}")


### PR DESCRIPTION
This PR ensures that one-year summary tables always show all classes or categories, instead of just those with transactions. There's also a minor bugfix for bulk statement imports, where the parser was trying to convert the wrong column into a date.